### PR TITLE
Fixed EncryptedStringW and reduced clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,7 +82,7 @@ macro_rules! protected {
         )}
     }};
     (cwstr $x: literal) => {{
-        unsafe {$crate::strings::encrypted_a::EncryptedStringW::new(
+        unsafe {$crate::strings::encrypted_w::EncryptedStringW::new(
             $crate::marker_name!($x),
         )}
     }};

--- a/src/licensing.rs
+++ b/src/licensing.rs
@@ -178,6 +178,36 @@ pub struct SerialNumberData {
     running_time: Duration,
     user_data: Vec<u8>,
 }
+impl SerialNumberData {
+    #[inline(always)]
+    pub fn state(&self) -> SerialState {
+        self.state
+    }
+    #[inline(always)]
+    pub fn user_name(&self) -> &str {
+        &self.user_name
+    }
+    #[inline(always)]
+    pub fn email(&self) -> &str {
+        &self.email
+    }
+    #[inline(always)]
+    pub fn expire(&self) -> Option<Date<Utc>> {
+        self.expire
+    }
+    #[inline(always)]
+    pub fn max_build(&self) -> Option<Date<Utc>> {
+        self.max_build
+    }
+    #[inline(always)]
+    pub fn running_time(&self) -> Duration {
+        self.running_time
+    }
+    #[inline(always)]
+    pub fn user_data(&self) -> &[u8] {
+        &self.user_data
+    }
+}
 
 #[derive(Debug, PartialEq)]
 pub enum ActivationStatus {

--- a/src/markers.rs
+++ b/src/markers.rs
@@ -13,28 +13,33 @@ use vmprotect_sys::VMProtectBeginVirtualization;
 use vmprotect_sys::VMProtectBeginVirtualizationLockByKey;
 use vmprotect_sys::VMProtectEnd;
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline(always)]
 #[doc(hidden)]
 pub fn begin_mutation(str: *const c_char) {
     unsafe { VMProtectBeginMutation(str) };
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline(always)]
 #[doc(hidden)]
 pub fn begin_virtualization(str: *const c_char) {
     unsafe { VMProtectBeginVirtualization(str) };
 }
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline(always)]
 #[doc(hidden)]
 pub fn begin_virtualization_lock_by_key(str: *const c_char) {
     unsafe { VMProtectBeginVirtualizationLockByKey(str) };
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline(always)]
 #[doc(hidden)]
 pub fn begin_ultra(str: *const c_char) {
     unsafe { VMProtectBeginUltra(str) };
 }
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 #[inline(always)]
 #[doc(hidden)]
 pub fn begin_ultra_lock_by_key(str: *const c_char) {

--- a/src/strings/encrypted_a.rs
+++ b/src/strings/encrypted_a.rs
@@ -36,10 +36,10 @@ impl Deref for EncryptedStringA<'_> {
         unsafe { std::str::from_utf8_unchecked(slice) }
     }
 }
-impl<'t> Into<String> for EncryptedStringA<'t> {
+impl<'t> From<EncryptedStringA<'t>> for String {
     #[inline(always)]
-    fn into(self) -> String {
-        self.to_owned()
+    fn from(val: EncryptedStringA<'t>) -> Self {
+        val.to_owned()
     }
 }
 impl<'t> fmt::Display for EncryptedStringA<'t> {

--- a/vmprotect-macros/src/lib.rs
+++ b/vmprotect-macros/src/lib.rs
@@ -37,7 +37,7 @@ pub fn protected(attr: TokenStream, fn_ts: TokenStream) -> TokenStream {
         vis,
         sig,
         block,
-    } = syn::parse(fn_ts.clone()).expect("failed to parse as fn");
+    } = syn::parse(fn_ts).expect("failed to parse as fn");
     let mut name = "vmprotect_".to_owned();
     name.push_str(&prot_type);
     if lock {
@@ -49,7 +49,7 @@ pub fn protected(attr: TokenStream, fn_ts: TokenStream) -> TokenStream {
     let wrapped_ident = syn::Ident::new(&name, sig.ident.span());
     let wrapper = syn::ItemFn {
         attrs: attrs.clone(),
-        vis: vis.clone(),
+        vis,
         sig: sig.clone(),
         block: {
             let mut args: Punctuated<_, syn::token::Comma> = Punctuated::new();
@@ -69,7 +69,7 @@ pub fn protected(attr: TokenStream, fn_ts: TokenStream) -> TokenStream {
             .unwrap()
         },
     };
-    let mut wrapped_sig = sig.clone();
+    let mut wrapped_sig = sig;
     wrapped_sig.ident = wrapped_ident;
     let wrapped = syn::ItemFn {
         attrs,

--- a/vmprotect-sys/src/lib.rs
+++ b/vmprotect-sys/src/lib.rs
@@ -1,6 +1,6 @@
 use std::os::raw::{c_char, c_void};
 
-/// Original API implementation
+// Original API implementation
 #[cfg_attr(
     all(not(target_os = "macos"), target_pointer_width = "64"),
     link(name = "VMProtectSDK64")


### PR DESCRIPTION
I tried to use the `cwstr` option of the `protected!` macro and was met with an error because the module path to `EncryptedStringW` was pointing to `encrypted_a` rather than `encrypted_w`.

This PR fixes the above issue and also implements getters for the fields on `SerialNumberData` and other warnings from `clippy`. Let me know if these other fixes should be broken out into a separate pull request.